### PR TITLE
Suggestions

### DIFF
--- a/dcandy.c
+++ b/dcandy.c
@@ -1,12 +1,13 @@
 /* dcandy.c */
 
-typedef unsigned char   b1_t;
-typedef unsigned short  b2_t;
-typedef unsigned int    b4_t;
-typedef unsigned double b8_t;
+typedef unsigned char   	b1_t;
+typedef unsigned short  	b2_t;
+typedef unsigned int    	b4_t;
+typedef unsigned long long	b8_t;
 
-#define SUCCESS 0
-#define FAILURE 1
+enum {	SUCCESS = 0 ,
+	FAILURE = 1
+     };
 
 // See fcserver.cpp/FCServer::mainLoop()
 void main_loop();
@@ -17,7 +18,7 @@ void start_listening();
 void main_loop()
 {
 	// Indefinite loop
-	for (;;)
+	while(1)
 	{
 		// Loop through connected USB devices and flush their communication 
 		// streams.

--- a/dcandy.c
+++ b/dcandy.c
@@ -1,9 +1,12 @@
 /* dcandy.c */
 
-typedef unsigned char   	b1_t;
-typedef unsigned short  	b2_t;
-typedef unsigned int    	b4_t;
-typedef unsigned long long	b8_t;
+#include <stdint.h>
+
+
+typedef unsigned uint_least8_t   	b1_t;
+typedef unsigned uint_least16_t  	b2_t;
+typedef unsigned uint_least32_t    	b4_t;
+typedef unsigned uint_least64_t		b8_t;
 
 enum {	SUCCESS = 0 ,
 	FAILURE = 1
@@ -39,7 +42,7 @@ void start_listening()
 	return;
 }
 
-int main()
+int main(int argc, char** argv)
 {
 	// Initialize libusb context/struct
 	


### PR DESCRIPTION
1) Changed typedef unsigned DOUBLE to LONG LONG--I don't know how GCC's GMP/GNU MPFR handles float-point values, but if it resembles IEEE 754, "unsigned double" is not a thing; the first bit is a sign flag regardless. 
  [EDIT: I followed the trend and assumed you meant to use an 8-byte unsigned integer.]

2) I read best practice is to not use #DEFINE for constants, but rather ENUM types or use CONST qualifier.

3) I read WHILE(1) evaluates faster than FOR(;;).